### PR TITLE
safeguard-db 컨테이너 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   db:
-    image: postgis/postgis:17-3.5-alpine
+    image: postgis/postgis:16-3.4-alpine
     container_name: safeguard-db
     environment:
       POSTGRES_USER: user
@@ -11,7 +11,7 @@ services:
     ports:
       - "5433:5432"
     volumes:
-      - postgres_data_17:/var/lib/postgresql/data
+      - postgres_data_16:/var/lib/postgresql/data
       - ./prisma/init.sql:/docker-entrypoint-initdb.d/init.sql
     networks:
       - safeguard-network
@@ -136,7 +136,7 @@ services:
       - safeguard-network
 
 volumes:
-  postgres_data_17:
+  postgres_data_16:
 
 
 networks:


### PR DESCRIPTION
⚠️ 주의: DB (PostGIS) 버전

두 환경(Windows, Mac)에서 모두 문제없이 실행하려면 `16-3.4-alpine`  버전을 사용해야함


```
  db:
    image: postgis/postgis:16-3.4-alpine  # Windows, Mac M1/M2 모두 안정적
    volumes:
      - postgres_data_16:/var/lib/postgresql/data # 볼륨도 버전에 맞게 변경
```

