### PR TITLE
feat: 민원 접수 페이지 개선 및 홈 화면 로그인 체크 구현

### DIFF
--- a/frontend/src/pages/ApplyText.tsx
+++ b/frontend/src/pages/ApplyText.tsx
@@ -2,6 +2,8 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { complaintsAPI, getToken, analyzeText } from '../utils/api';
 
+const MAX_CONTENT_LENGTH = 1000;
+
 function ApplyText() {
     const navigate = useNavigate();
     const mapRef = useRef<HTMLDivElement>(null);
@@ -213,11 +215,6 @@ function ApplyText() {
     };
 
     const handleAnalyze = async () => {
-
-        const result = await analyzeText(formData.content);
-        console.log('AI RESULT RAW:', result);
-        setAiResult(result);
-
         if (!formData.content || formData.content.length < 8) {
             alert('민원 내용을 8자 이상 입력해주세요.');
             return;
@@ -434,7 +431,17 @@ function ApplyText() {
                                     }}
                                     onFocus={(e) => e.target.style.borderColor = '#7c3aed'}
                                     onBlur={(e) => e.target.style.borderColor = '#e2e8f0'}
+                                    maxLength={MAX_CONTENT_LENGTH}
                                 />
+                                <div style={{
+                                    textAlign: 'right',
+                                    marginTop: '6px',
+                                    fontSize: '0.85rem',
+                                    color: formData.content.length > MAX_CONTENT_LENGTH * 0.9 ? '#ef4444' : '#94a3b8',
+                                    fontWeight: '500'
+                                }}>
+                                    {formData.content.length.toLocaleString()} / {MAX_CONTENT_LENGTH.toLocaleString()}자
+                                </div>
                             </div>
 
                             {/* 파일 첨부 */}
@@ -705,17 +712,17 @@ function ApplyText() {
                             {/* 민원 접수하기 버튼 (여기로 이동됨) */}
                             <button
                                 onClick={handleAnalyze}
-                                disabled={analyzing || !formData.content}
+                                disabled={analyzing || !formData.content || formData.content.length < 8}
                                 style={{
                                     width: '100%',
                                     padding: '16px',
-                                    background: (analyzing || !formData.content) ? '#94a3b8' : 'linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)',
+                                    background: (analyzing || !formData.content || formData.content.length < 8) ? '#94a3b8' : 'linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)',
                                     color: 'white',
                                     border: 'none',
                                     borderRadius: '12px',
                                     fontSize: '1rem',
                                     fontWeight: '700',
-                                    cursor: (analyzing || !formData.content) ? 'not-allowed' : 'pointer',
+                                    cursor: (analyzing || !formData.content || formData.content.length < 8) ? 'not-allowed' : 'pointer',
                                     boxShadow: '0 4px 14px rgba(59, 130, 246, 0.4)',
                                     transition: 'all 0.3s'
                                 }}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { getToken } from '../utils/api';
 
 function Home() {
     const navigate = useNavigate();
@@ -131,7 +132,14 @@ function Home() {
                         {cards.map(card => (
                             <div
                                 key={card.path}
-                                onClick={() => navigate(card.path)}
+                                onClick={() => {
+                                    if (!getToken()) {
+                                        alert('로그인이 필요합니다.');
+                                        navigate('/login');
+                                    } else {
+                                        navigate(card.path);
+                                    }
+                                }}
                                 style={{
                                     backgroundColor: 'white',
                                     borderRadius: '20px',
@@ -245,6 +253,9 @@ function Home() {
 
             {/* 민원 피드 섹션 */}
             <div style={{
+                maxWidth: '1200px',
+                margin: '40px auto 80px',
+                padding: '0 20px',
                 display: 'grid',
                 gridTemplateColumns: 'repeat(2, 1fr)',
                 gap: '24px'

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -16,8 +16,6 @@ function Login() {
 
         try {
             const result = await authAPI.login({ userId, password });
-            alert(`환영합니다, ${result.user.name}님!`);
-
             if (result.user.role === 'AGENCY') {
                 window.location.href = '/admin/dashboard';
             } else {


### PR DESCRIPTION
- ApplyText: 글자 수 제한(1000자) 및 카운터 추가, 분석 버튼 활성화 조건 변경

- ApplyImage: 현위치 자동 감지, 주소 검색(Daum 우편번호) 연동 UI 적용

- ApplyImage: 작성 단계 클릭 시 해당 섹션 포커스 및 자동 동작(파일창/주소창 열기) 구현

- Home: 민원 신청 버튼 클릭 시 로그인 체크 로직 추가

- Login: 불필요한 로그인 성공 알림 제거